### PR TITLE
Set style fix

### DIFF
--- a/code/api/src/modules/tests/user/mutation.test.js
+++ b/code/api/src/modules/tests/user/mutation.test.js
@@ -11,13 +11,12 @@ describe('user mutations', () => {
     it('can set a users style to casual', async (done) => {
         const response = await request(server)
             .post('/graphql')
-            .send({ query: 'mutation { setStyle(id: 1 style:"casual") { style id } }' })
+            .send({ query: 'mutation { setStyle(style:"casual") { style } }' })
             .expect(200);
           expect(response.body).toMatchObject({
             data: {
               setStyle: {
-                style: "casual",
-                id: 1
+                style: "casual"
               }
             }
           })
@@ -27,13 +26,12 @@ describe('user mutations', () => {
     it('can set a users style to formal', async (done) => {
         const response = await request(server)
             .post('/graphql')
-            .send({ query: 'mutation { setStyle(id: 1 style:"formal") { style id } }' })
+            .send({ query: 'mutation { setStyle(style:"formal") { style } }' })
             .expect(200);
           expect(response.body).toMatchObject({
             data: {
               setStyle: {
-                style: "formal",
-                id: 1
+                style: "formal"
               }
             }
           })
@@ -43,7 +41,7 @@ describe('user mutations', () => {
     it('cannot set a users style with blank string', async (done) => {
         const response = await request(server)
             .post('/graphql')
-            .send({ query: 'mutation { setStyle(id: 1 style:"") { style id } }' })
+            .send({ query: 'mutation { setStyle(style:"") { style } }' })
             .expect(200);
           expect(response.body.errors.[0].message).toBe("You must enter a style to set a user's style")
         done();
@@ -52,7 +50,7 @@ describe('user mutations', () => {
     it('cannot set a users style with the wrong data type', async (done) => {
         const response = await request(server)
             .post('/graphql')
-            .send({ query: 'mutation { setStyle(id: 1 style:7) { style id } }' })
+            .send({ query: 'mutation { setStyle(style:7) { style } }' })
             .expect(400);
           expect(response.body.errors.[0].message).toBe("Expected type String, found 7.")
         done();

--- a/code/api/src/modules/tests/utils.js
+++ b/code/api/src/modules/tests/utils.js
@@ -5,7 +5,13 @@ import schema from '../../setup/schema';
 let server = express();
 server.use("/", graphqlHTTP({
     schema: schema,
-    graphiql: false
+    graphiql: false,
+    context: {
+      auth: {
+        user: { id: 1 },
+        isAuthenticated: true
+      }
+    }
 }));
 
 module.exports = server;

--- a/code/api/src/modules/user/mutations.js
+++ b/code/api/src/modules/user/mutations.js
@@ -45,10 +45,6 @@ export const setStyle = {
     style: {
       name: 'style',
       type: GraphQLString
-    },
-    id: {
-      name: 'id',
-      type: GraphQLInt
     }
   },
   resolve: updateStyle

--- a/code/api/src/modules/user/resolvers.js
+++ b/code/api/src/modules/user/resolvers.js
@@ -59,15 +59,15 @@ export async function login(parentValue, { email, password }) {
 }
 
 // set style
-export async function updateStyle(parentValue, { style, id }) {
-  if (style !== "") {
+  export async function updateStyle(parentValue, { style }, { auth }) { 
+  if (style !== "" && auth.user && auth.user.id > 0) {
     await models.User.update(
       {
         style
       },
-      { where: { id } }
+      {where: { id: auth.user.id } }
     );
-    return await models.User.findOne({ where: { id } })
+    return await models.User.findOne({ where: { id: auth.user.id } })
   } else {
     throw new Error(`You must enter a style to set a user's style`)
   }


### PR DESCRIPTION
### This PRs additions:
Adds passing happy path testing for the updated setStyle (setStyle no longer requires user id as an argument)
Edits utils.js to hold context of a mocked current user's id `{ context: { auth: { user: { id: 1 } } } } }`
 
### Relevant tickets: 
closes #70 
 
### Screenshots:

 
### Questions: 
