### PR TITLE
Add testing for list, item and state

### DIFF
--- a/code/web/package.json
+++ b/code/web/package.json
@@ -12,8 +12,8 @@
     "build:client:prod": "webpack -p",
     "build:server:prod": "babel src -s -D -d build",
     "start:server:prod": " node build/index.js",
-    "test": "jest",
-    "storybook": "start-storybook -p 9000 -c storybook"
+    "storybook": "start-storybook -p 9000 -c storybook",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -37,6 +37,7 @@
     "nodemon": "2.0.4",
     "redux-devtools-extension": "^2.13.8",
     "react-test-renderer": "^17.0.1",
+    "redux-mock-store": "^1.5.4",
     "webpack": "4.44.2",
     "webpack-cli": "3.3.12"
   },
@@ -51,12 +52,14 @@
     "js-cookie": "^2.2.1",
     "morgan": "1.10.0",
     "prop-types": "^15.7.2",
+    "pg": "^8.5.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-helmet": "^6.1.0",
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "styled-jsx": "3.3.0",
     "validator": "13.1.17"

--- a/code/web/src/modules/survey/Survey/Item.js
+++ b/code/web/src/modules/survey/Survey/Item.js
@@ -29,12 +29,13 @@ class Item extends PureComponent {
 
   handleItemClick = () => {
     this.setState({ selected: !this.state.selected });
-    this.props.updateSelectedItems(this.props.item, !this.state.selected, this.props.page)
+    this.props.updateSelectedItems(this.props.item, this.state.selected)
   }
 
   render() {
     return (
       <img
+        alt={this.props.item.image}
         src={routeImage + this.props.item.image}
         style={{
           height: '5em',
@@ -55,4 +56,4 @@ function itemState(state) {
   }
 }
 
-export default connect(itemState, {updateSelectedItems})(withRouter(Item))
+export default connect(itemState, { updateSelectedItems })(withRouter(Item))

--- a/code/web/src/modules/survey/Survey/List.js
+++ b/code/web/src/modules/survey/Survey/List.js
@@ -146,4 +146,4 @@ function listState(state) {
   }
 }
 
-export default connect(listState, { deletePageSelections, getSurveyItems, setStyle })(withRouter(List))
+export default connect(listState, { deletePageSelections, getSurveyItems, setStyle })(withRouter(List)) 

--- a/code/web/src/modules/survey/Survey/List.js
+++ b/code/web/src/modules/survey/Survey/List.js
@@ -146,4 +146,4 @@ function listState(state) {
   }
 }
 
-export default connect(listState, { deletePageSelections, getSurveyItems, setStyle })(List)
+export default connect(listState, { deletePageSelections, getSurveyItems, setStyle })(withRouter(List))

--- a/code/web/src/modules/survey/Survey/testing/Item.test.js
+++ b/code/web/src/modules/survey/Survey/testing/Item.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from "react-router-dom";
+import { createMemoryHistory } from 'history';
+import { Provider } from 'react-redux';
+import Item from '../Item.js'
+import { store } from '../../../../setup/store'
+
+describe('Survey List', () => {
+  let history, item;  
+  beforeEach(() => {
+    item = {
+      image:"image1.jpg",
+      score:1,
+    }
+    history = createMemoryHistory()
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Item item={item} page={1} />
+         </MemoryRouter>
+      </Provider>
+    )
+  })
+  
+  it('should display an item', () => {
+    expect(screen.getByAltText('image1.jpg')).toBeInTheDocument()
+  })
+});

--- a/code/web/src/modules/survey/Survey/testing/List.test.js
+++ b/code/web/src/modules/survey/Survey/testing/List.test.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { getAllByRole, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Router } from "react-router-dom";
+import { createMemoryHistory } from 'history';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import configureMockStore from "redux-mock-store";
+import thunk from "redux-thunk";
+import List from '../List.js'
+
+describe('Survey List', () => {
+  const mockStore = configureMockStore([thunk]);
+  const store = mockStore({
+    surveyItems: {
+      isLoading: false,
+      surveyItems: [
+        {
+          image:"image1.jpg",
+          score:1,
+        }
+      ],
+      error: null,
+    },
+    selectedItems: {
+      selectedItems: {
+        1:[
+          {
+            image:"image2.jpg",
+            score:2,
+          }
+        ],
+        2:[],
+        3:[],
+        4:[]
+      }
+    }
+  });
+
+  store.dispatch = jest.fn()
+  
+  let history;
+  
+  beforeEach(() => {
+    history = createMemoryHistory()
+    render(
+      <Provider store={store} key="provider">
+        <Router history={history}>
+          <List />
+         </Router>
+      </Provider>
+    )
+  })
+  
+  it('should display the survey items from the store', async () => {
+    const renderedItem1 = await waitFor(() => screen.getByAltText('image1.jpg'))
+    expect(renderedItem1).toBeInTheDocument()
+  })
+  
+  it('should display a next button', () => {
+    expect(screen.getByRole('button', { name: /Next/i })).toBeInTheDocument()
+  })
+
+  it('should have a back button', () => {
+    expect(screen.getByRole('button', { name: /Back/i })).toBeInTheDocument()
+  })
+  
+  it('next button should be disabled onload', () => {
+    expect(screen.getByRole('button', { name: /Next/i })).toBeDisabled()
+  })
+})

--- a/code/web/src/modules/survey/Survey/testing/state.test.js
+++ b/code/web/src/modules/survey/Survey/testing/state.test.js
@@ -5,7 +5,7 @@ import { MemoryRouter, Router } from "react-router-dom";
 import { createMemoryHistory } from 'history';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import { SURVEY_GET_ITEMS_RESPONSE, ITEM_SELECT, ITEM_DESELECT } from '../../api/actions'
+import { SURVEY_GET_ITEMS_RESPONSE, ITEM_SELECT, ITEM_DESELECT, ITEMS_DELETE } from '../../api/actions'
 import { store } from '../../../../setup/store';
 
 import Item from '../Item';
@@ -24,7 +24,7 @@ describe('', () => {
         image:"image2.jpg",
         score:2,
       }
-    ]
+    ] 
   })
 
   it('should store survey items', () => {
@@ -52,12 +52,18 @@ describe('', () => {
       item: {
         image:"image1.jpg",
         score:1,
-      }
+      },
+      page: 1
     }
     let mockState = { 
-      selectedItems: [] 
+      selectedItems: {
+        1:[],
+        2:[],
+        3:[],
+        4:[]
+      }
     }
-    expect(surveyReducers.selectedItems(mockState, mockUpdateSelectedItems)).toEqual({ selectedItems: [mockSurveyItems[0]] })
+    expect(surveyReducers.selectedItems(mockState, mockUpdateSelectedItems)).toEqual({ selectedItems: { 1: [mockSurveyItems[0]], 2: [], 3: [], 4: [] } })
   })
   it('should remove selected items', () => {
     const mockUpdateSelectedItems = {
@@ -65,20 +71,47 @@ describe('', () => {
       item: {
         image:"image2.jpg",
         score:2,
-      }
+      },
+      page: 1
     }
     let mockState = { 
-      selectedItems: [
-        {
-          image:"image1.jpg",
-          score:1,
-        },
-        {
-          image:"image2.jpg",
-          score:2,
-        }
-      ] 
+      selectedItems: {
+        1:[
+          {
+            image:"image2.jpg",
+            score:2,
+          }
+        ],
+        2:[],
+        3:[],
+        4:[]
+      }
     }
-    expect(surveyReducers.selectedItems(mockState, mockUpdateSelectedItems)).toEqual({ selectedItems: [mockSurveyItems[0]] })
+    expect(surveyReducers.selectedItems(mockState, mockUpdateSelectedItems)).toEqual({ selectedItems: { 1: [], 2: [], 3: [], 4: [] } })
+  })
+  it('should be able to delete selected items', () => {
+    const mockUpdateSelectedItems = {
+      type: ITEMS_DELETE,
+      page: 2
+    }
+    mockState = {
+      selectedItems: {
+        1: [
+          {
+            image:"image1.jpg",
+            score:1,
+          }
+        ],
+        2: [
+          {
+            image:"image2.jpg",
+            score:2,
+          }
+        ],
+        3: [],
+        4: []
+      }
+    }
+    expect(surveyReducers.selectedItems(mockState, mockUpdateSelectedItems)).toEqual({ selectedItems: { 1: [ mockSurveyItems[0]], 2: [], 3: [], 4: [] } })
   })
 })

--- a/code/web/src/modules/survey/api/actions.js
+++ b/code/web/src/modules/survey/api/actions.js
@@ -14,6 +14,16 @@ export const ITEMS_DELETE = 'Survey/ITEM_DELETE'
 export const ITEM_DESELECT = 'Survey/ITEM_DESELECT'
 export const NULL = 'NULL'
 
+export const getSurveyItemsFromAPI = (clothingType) => {
+  return axios.post(routeApi, query({
+    operation:"getSurveyItems",
+    variables: {
+      type: clothingType
+    },
+    fields:["image", "score"]
+  }))
+}
+
 export const getSurveyItems = (clothingType) => {
   if (clothingType === null) return (dispatch) => dispatch({type: 'NULL',isLoading:true})
   return (dispatch) => {
@@ -25,13 +35,7 @@ export const getSurveyItems = (clothingType) => {
       }
     )
 
-    return axios.post(routeApi, query({
-      operation:"getSurveyItems",
-      variables: {
-        type: clothingType
-      },
-      fields:["image", "score"]
-    }))
+    getSurveyItemsFromAPI(clothingType)
     .then(response => {
       if (response.status === 200) {
         dispatch(


### PR DESCRIPTION
### This PRs additions:
*Adds testing for frontend survey track files:
  * Adds testing for `Survey/List.js`
  * Adds testing for `Survey/Item.js`
  * Adds testing for `survey/api/state.js`
 
### Reviewer starting point: 
`/code/web/src/module/survey/Survey/testing/`
 
### How to manually test:  
npm test
 
### background context:  
Mocking the store and dispatch were the critical piece to getting List.test.js to work. 
 
### Relevant tickets: 
Closes #27 
Closes #82
 
### Screenshots:
N/A
 
### Questions: 
N/A