### PR TITLE
Add testing for crate reducer

### DIFF
--- a/code/web/src/modules/crate/api/state.test.js
+++ b/code/web/src/modules/crate/api/state.test.js
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import {
+  CRATES_GET_LIST_REQUEST,
+  CRATES_GET_LIST_RESPONSE,
+  CRATES_GET_LIST_FAILURE,
+  CRATES_GET_REQUEST,
+  CRATES_GET_RESPONSE,
+  CRATES_GET_FAILURE,
+} from './actions'
+
+import * as crateReducers from './state'
+
+describe('', () => {
+  let mockState, mockCrates;
+  beforeEach(() => {
+    mockState = {};
+    mockCrates = [
+      {
+        id:1,
+        name:"Clothes for Men",
+        description:"A monthly supply of trendy clothes for men.",
+        createdAt:"1607745183891",
+        updatedAt:"1607745183891"
+      }
+    ] 
+  })
+
+  it('should store crates items', () => {
+    const mockGetCrates = {
+      type:  CRATES_GET_LIST_RESPONSE,
+      error: null,
+      isLoading: false,
+      list: [
+        {
+          id:1,
+          name:"Clothes for Men",
+          description:"A monthly supply of trendy clothes for men.",
+          createdAt:"1607745183891",
+          updatedAt:"1607745183891"
+        }
+      ]
+    }
+    const expectedCrates = {
+      error: null,
+      isLoading: false,
+      list: [
+        {
+          id:1,
+          name:"Clothes for Men",
+          description:"A monthly supply of trendy clothes for men.",
+          createdAt:"1607745183891",
+          updatedAt:"1607745183891"
+        }
+      ]
+    }
+    expect(crateReducers.crates({}, mockGetCrates)).toEqual(expectedCrates)
+  })
+});


### PR DESCRIPTION
### This PRs additions:
* Adds testing for crate reducers
 
### Reviewer starting point: 
/code/web/src/modules/crate/api/state.test.js
 
### How to manually test:  
npm test
 
### background context:  
N/A
 
### Relevant tickets: 
Closes #22 
 
### Screenshots:
N/A
 
### Questions: 
N/A