### PR TITLE
Add testing for subscriptionsByUser reducer

### DIFF
--- a/code/web/src/modules/subscription/api/state.test.js
+++ b/code/web/src/modules/subscription/api/state.test.js
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+import {
+  SUBSCRIPTIONS_GET_LIST_BY_USER_RESPONSE
+} from './actions'
+
+import * as subscriptionReducers from './state'
+
+describe('', () => {
+  it('should store crates items', () => {
+    const mockGetSubscriptionsByUser = {
+      type:  SUBSCRIPTIONS_GET_LIST_BY_USER_RESPONSE,
+      error: null,
+      isLoading: false,
+      list: [
+        {
+          id:1,
+          user: {
+            name:"testUser1",
+            email:"testuser1@crate.com"
+          },
+          crate: {
+            id: 1,
+            name: "Clothes for Men",
+            description: "A monthly supply of trendy clothes for men."
+          },
+          createdAt: "1607808308941"
+        }
+      ]
+    }
+    const expectedSubscriptions = {
+      error: null,
+      isLoading: false,
+      list: [
+        {
+          id:1,
+          user: {
+            name:"testUser1",
+            email:"testuser1@crate.com"
+          },
+          crate: {
+            id: 1,
+            name: "Clothes for Men",
+            description: "A monthly supply of trendy clothes for men."
+          },
+          createdAt: "1607808308941"
+        }
+      ]
+    }
+    expect(subscriptionReducers.subscriptionsByUser({}, mockGetSubscriptionsByUser)).toEqual(expectedSubscriptions)
+  })
+});


### PR DESCRIPTION
### This PRs additions:
* Adds testing for subscription reducer
 
### Reviewer starting point: 
`/code/web/src/modules/subscription/api/state.test.js`
 
### How to manually test:  
npm test
 
### background context:  
N/A
 
### Relevant tickets: 
Closes #23 
 
### Screenshots:
N/A
 
### Questions: 
N/A